### PR TITLE
Pool 2066 Sentry errors

### DIFF
--- a/lib/components/PrizePoolDepositList/PrizePoolDepositBalance.tsx
+++ b/lib/components/PrizePoolDepositList/PrizePoolDepositBalance.tsx
@@ -12,7 +12,7 @@ export const PrizePoolDepositBalance = (props: PrizePoolDepositBalanceProps) => 
   const { chainId, token } = props
 
   let balanceToDisplay = token.amountPretty
-  if (Boolean((token as TokenWithUsdBalance).balanceUsd)) {
+  if (!(token as TokenWithUsdBalance).balanceUsdScaled.isZero()) {
     balanceToDisplay = `$${(token as TokenWithUsdBalance).balanceUsd.amountPretty}`
   }
 

--- a/lib/hooks/v3/useAllUsersV3Balances.ts
+++ b/lib/hooks/v3/useAllUsersV3Balances.ts
@@ -35,9 +35,9 @@ export interface V3PrizePoolBalances {
  * @returns
  */
 export const useAllUsersV3Balances = (usersAddress: string) => {
-  const chainIds = useV3ChainIds()
-  const providers = useReadProviders(chainIds)
   const { data: v3PrizePools, isFetched } = useV3PrizePools()
+  const chainIds = isFetched ? Object.keys(v3PrizePools).map(Number) : []
+  const providers = useReadProviders(chainIds)
   const { data: tokenPrices } = useCoingeckoTokenPricesAcrossChains(
     isFetched ? getTokenAddressesFromPrizePools(v3PrizePools) : null
   )

--- a/lib/hooks/v3/useLPTokenUsdValue.ts
+++ b/lib/hooks/v3/useLPTokenUsdValue.ts
@@ -28,18 +28,14 @@ export const useLPTokenUsdValue = (prizePool: V3PrizePool) => {
   )
 
   const isFetched = isTokenPricesFetched && tokenBalancesIsFetched
+  const token1BalanceData = tokenBalancesIsFetched && lPTokenBalances[token1Address]
+  const token2BalanceData = tokenBalancesIsFetched && lPTokenBalances[token2Address]
 
   const lpTokenValueUsd =
-    isFetched && Boolean(lPTokenBalances)
+    isFetched && !!token1BalanceData && !!token2BalanceData
       ? calculateLPTokenPrice(
-          formatUnits(
-            lPTokenBalances[token1Address].amountUnformatted,
-            lPTokenBalances[token1Address].decimals
-          ),
-          formatUnits(
-            lPTokenBalances[token2Address].amountUnformatted,
-            lPTokenBalances[token2Address].decimals
-          ),
+          formatUnits(token1BalanceData.amountUnformatted, token1BalanceData.decimals),
+          formatUnits(token2BalanceData.amountUnformatted, token2BalanceData.decimals),
           tokenPrices[token1Address]?.usd,
           tokenPrices[token2Address]?.usd,
           lPTokenBalances[lpTokenAddress].totalSupply

--- a/lib/hooks/v3/useLPTokenUsdValue.ts
+++ b/lib/hooks/v3/useLPTokenUsdValue.ts
@@ -29,15 +29,17 @@ export const useLPTokenUsdValue = (prizePool: V3PrizePool) => {
 
   const isFetched = isTokenPricesFetched && tokenBalancesIsFetched
   const token1BalanceData = tokenBalancesIsFetched && lPTokenBalances[token1Address]
+  const token1ValueUsd = tokenPrices && tokenPrices?.[token1Address]?.usd
   const token2BalanceData = tokenBalancesIsFetched && lPTokenBalances[token2Address]
+  const token2ValueUsd = tokenPrices && tokenPrices?.[token2Address]?.usd
 
   const lpTokenValueUsd =
-    isFetched && !!token1BalanceData && !!token2BalanceData
+    isFetched && !!token1BalanceData && !!token2BalanceData && !!token1ValueUsd && !token2ValueUsd
       ? calculateLPTokenPrice(
           formatUnits(token1BalanceData.amountUnformatted, token1BalanceData.decimals),
           formatUnits(token2BalanceData.amountUnformatted, token2BalanceData.decimals),
-          tokenPrices[token1Address]?.usd,
-          tokenPrices[token2Address]?.usd,
+          token1ValueUsd,
+          token2ValueUsd,
           lPTokenBalances[lpTokenAddress].totalSupply
         )
       : null

--- a/lib/hooks/v3/useUsersV3LPPoolBalances.ts
+++ b/lib/hooks/v3/useUsersV3LPPoolBalances.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 
 import { BigNumber } from 'ethers'
 import { getAmountFromBigNumber } from 'lib/utils/getAmountFromBigNumber'
-import { LP_PRIZE_POOL_METADATA, POOL_PRIZE_POOL_ADDRESSES } from 'lib/constants/v3'
+import { LP_PRIZE_POOL_METADATA } from 'lib/constants/v3'
 import { useAllUsersV3Balances, V3PrizePoolBalances } from './useAllUsersV3Balances'
 
 /**

--- a/lib/hooks/v3/useV3PrizePools.ts
+++ b/lib/hooks/v3/useV3PrizePools.ts
@@ -66,11 +66,15 @@ const getV3PrizePools = async (
     [chainId: number]: V3PrizePool[]
   } = {}
 
-  await Promise.all(
+  await Promise.allSettled(
     chainIds.map(async (chainId) => {
       const prizePoolAddresses = prizePoolAddressByChainId[chainId]
-      const prizePools = await getPrizePools(chainId, providers[chainId], prizePoolAddresses)
-      prizePoolsByChainId[chainId] = prizePools
+      try {
+        const prizePools = await getPrizePools(chainId, providers[chainId], prizePoolAddresses)
+        prizePoolsByChainId[chainId] = prizePools
+      } catch (e) {
+        console.log(e.message)
+      }
     })
   )
 

--- a/lib/hooks/v4/PrizeDistributor/useUnclaimedDrawIds.ts
+++ b/lib/hooks/v4/PrizeDistributor/useUnclaimedDrawIds.ts
@@ -9,7 +9,9 @@ export const useUnclaimedDrawIds = (usersAddress: string, prizeDistributor: Priz
     ...useQueryResponse
   } = useUsersUnclaimedDrawDatas(usersAddress, prizeDistributor)
 
-  if (!isFetched) return { data: null, isFetched, ...useQueryResponse }
+  if (!isFetched || !unclaimedDrawDatas?.[usersAddress]) {
+    return { data: null, isFetched, ...useQueryResponse }
+  }
 
   const drawDatas = unclaimedDrawDatas[usersAddress]
   const drawIds = drawDatas ? Object.keys(drawDatas).map(Number) : null

--- a/lib/hooks/v4/PrizeDistributor/useUsersStoredDrawResults.ts
+++ b/lib/hooks/v4/PrizeDistributor/useUsersStoredDrawResults.ts
@@ -12,6 +12,6 @@ export const useUsersStoredDrawResults = (
   }
 } => {
   const [drawResults] = useAtom(drawResultsAtom)
-  const usersDrawResults = drawResults[usersAddress]?.[prizeDistributor.id()] || {}
+  const usersDrawResults = drawResults?.[usersAddress]?.[prizeDistributor.id()] || {}
   return { [usersAddress]: usersDrawResults }
 }

--- a/lib/hooks/v4/PrizePool/useUsersV4Balances.ts
+++ b/lib/hooks/v4/PrizePool/useUsersV4Balances.ts
@@ -39,7 +39,7 @@ export const useUsersV4Balances = (usersAddress: string) => {
   return useMemo(() => {
     const isFetched = queryResults.every((queryResult) => queryResult.isFetched)
     const isFetching = queryResults.some((queryResult) => queryResult.isFetching)
-    const data = queryResults.map((queryResult) => queryResult.data)
+    const data = queryResults.map((queryResult) => queryResult.data).filter(Boolean)
     const totalValueUsdScaled = getTotalValueUsdScaled(data)
     const totalValueUsd = getAmountFromBigNumber(totalValueUsdScaled, '2')
     const refetch = () => queryResults.map((queryResult) => queryResult.refetch())

--- a/lib/views/Account/V3StakingDeposits/LPStakingCards.tsx
+++ b/lib/views/Account/V3StakingDeposits/LPStakingCards.tsx
@@ -13,6 +13,7 @@ import { getLPPrizePoolMetadata, useLPTokenUsdValue } from 'lib/hooks/v3/useLPTo
 import { useUsersV3LPPoolBalances } from 'lib/hooks/v3/useUsersV3LPPoolBalances'
 import { LPTokenIcon } from 'lib/components/LPTokenIcon'
 import { getAmountFromBigNumber } from 'lib/utils/getAmountFromBigNumber'
+import { BigNumber } from 'ethers'
 
 export const LPStakingCards = () => {
   const usersAddress = useUsersAddress()
@@ -98,7 +99,9 @@ const LPStakingCard = (props: { balances: V3PrizePoolBalances; refetch: () => vo
 }
 
 const makeTokenWithUsdBalance = (token: TokenWithBalance, usd: number): TokenWithUsdBalance => {
-  const balanceUsdUnformatted = amountMultByUsd(token.amountUnformatted, usd)
+  const balanceUsdUnformatted = usd
+    ? amountMultByUsd(token.amountUnformatted, usd)
+    : BigNumber.from(0)
   const balanceUsd = getAmountFromBigNumber(balanceUsdUnformatted, token.decimals)
   const balanceUsdScaled = toScaledUsdBigNumber(balanceUsd.amount)
   return {

--- a/lib/views/Prizes/MultiDrawsCard/PrizeVideoBackground.tsx
+++ b/lib/views/Prizes/MultiDrawsCard/PrizeVideoBackground.tsx
@@ -57,16 +57,19 @@ export const PrizeVideoBackground = (props: PrizeVideoBackgroundProps) => {
   }
 
   const showPrizeOrNoPrize = () => {
-    setCurrentVideoState(VideoState.transition)
-
-    if (!didUserWinAPrize) {
-      setCurrentVideoClip(VideoClip.noPrize)
-      c1.current.play()
-      c2.current.load()
-    } else {
-      setCurrentVideoClip(VideoClip.prize)
-      d1.current.play()
-      d2.current.load()
+    try {
+      setCurrentVideoState(VideoState.transition)
+      if (!didUserWinAPrize) {
+        setCurrentVideoClip(VideoClip.noPrize)
+        c1.current.play()
+        c2.current.load()
+      } else {
+        setCurrentVideoClip(VideoClip.prize)
+        d1.current.play()
+        d2.current.load()
+      }
+    } catch (e) {
+      console.log(e.message)
     }
   }
 
@@ -107,13 +110,17 @@ export const PrizeVideoBackground = (props: PrizeVideoBackgroundProps) => {
           b1.current.load()
         }}
         onEnded={() => {
-          if (checkedState !== CheckedState.unchecked) {
-            b1.current.play()
-            b2.current.load()
-            setCurrentVideoClip(VideoClip.reveal)
-            setCurrentVideoState(VideoState.transition)
-          } else {
-            a2.current.play()
+          try {
+            if (checkedState !== CheckedState.unchecked) {
+              b1.current.play()
+              b2.current.load()
+              setCurrentVideoClip(VideoClip.reveal)
+              setCurrentVideoState(VideoState.transition)
+            } else {
+              a2.current.play()
+            }
+          } catch (e) {
+            console.log(e.message)
           }
         }}
       >
@@ -137,10 +144,14 @@ export const PrizeVideoBackground = (props: PrizeVideoBackgroundProps) => {
           b2.current.load()
         }}
         onEnded={() => {
-          setCurrentVideoState(VideoState.loop)
-          b2.current.play()
-          c1.current.load()
-          d1.current.load()
+          try {
+            setCurrentVideoState(VideoState.loop)
+            b2.current.play()
+            c1.current.load()
+            d1.current.load()
+          } catch (e) {
+            console.log(e.message)
+          }
         }}
       >
         <source
@@ -161,10 +172,14 @@ export const PrizeVideoBackground = (props: PrizeVideoBackgroundProps) => {
         playsInline
         muted
         onEnded={() => {
-          if (checkedState === CheckedState.checking && didUserWinAPrize === undefined) {
-            b2.current.play()
-          } else {
-            showPrizeOrNoPrize()
+          try {
+            if (checkedState === CheckedState.checking && didUserWinAPrize === undefined) {
+              b2.current.play()
+            } else {
+              showPrizeOrNoPrize()
+            }
+          } catch (e) {
+            console.log(e.message)
           }
         }}
       >
@@ -186,8 +201,12 @@ export const PrizeVideoBackground = (props: PrizeVideoBackgroundProps) => {
         muted
         onPlay={() => setCheckedAnimationFinished()}
         onEnded={() => {
-          setCurrentVideoState(VideoState.loop)
-          c2.current.play()
+          try {
+            setCurrentVideoState(VideoState.loop)
+            c2.current.play()
+          } catch (e) {
+            console.log(e.message)
+          }
         }}
       >
         <source
@@ -208,7 +227,11 @@ export const PrizeVideoBackground = (props: PrizeVideoBackgroundProps) => {
         playsInline
         muted
         onEnded={() => {
-          c2.current.play()
+          try {
+            c2.current.play()
+          } catch (e) {
+            console.log(e.message)
+          }
         }}
       >
         <source
@@ -232,8 +255,12 @@ export const PrizeVideoBackground = (props: PrizeVideoBackgroundProps) => {
         muted
         onPlay={() => setCheckedAnimationFinished()}
         onEnded={() => {
-          setCurrentVideoState(VideoState.loop)
-          d2.current.play()
+          try {
+            setCurrentVideoState(VideoState.loop)
+            d2.current.play()
+          } catch (e) {
+            console.log(e.message)
+          }
         }}
       >
         <source
@@ -254,7 +281,11 @@ export const PrizeVideoBackground = (props: PrizeVideoBackgroundProps) => {
         playsInline
         muted
         onEnded={() => {
-          d2.current.play()
+          try {
+            d2.current.play()
+          } catch (e) {
+            console.log(e.message)
+          }
         }}
       >
         <source src={getVideoSource(VideoClip.prize, VideoState.loop, 'webm')} type='video/webm' />

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@pooltogether/current-pool-data": "^3.7.2",
     "@pooltogether/etherplex": "^1.1.4",
     "@pooltogether/evm-chains-extended": "^0.6.4-beta.1",
-    "@pooltogether/hooks": "^1.5.0",
+    "@pooltogether/hooks": "^1.5.1",
     "@pooltogether/pooltogether-contracts": "^3.4.4",
     "@pooltogether/react-components": "^1.6.29",
     "@pooltogether/utilities": "^0.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2763,10 +2763,10 @@
   resolved "https://registry.yarnpkg.com/@pooltogether/hardhat-deploy-markdown-export/-/hardhat-deploy-markdown-export-0.1.1.tgz#95c8fb6b63d4b721146917e11f53d24fc06f11cf"
   integrity sha512-qawd7dakhNIzk4CHbAI5lbEM25PuZXHfeIwLBQP5qxAVkDJnR7H7vAxksGdlHYYi4XddmC0W+QPlIFSAi8jTaA==
 
-"@pooltogether/hooks@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@pooltogether/hooks/-/hooks-1.5.0.tgz#f57e110e1aeb77810c2c463e4af4fc54cc5f7460"
-  integrity sha512-ibtE0PqC1FbOizs4QgloDvnJNi2Xom5TiwyGzhS3DOwBaL7aF0mhrOKBzzTvgFDDEiFHKYLb9anfr0vCXSe5Ng==
+"@pooltogether/hooks@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@pooltogether/hooks/-/hooks-1.5.1.tgz#c2ae145e010fb090c53193fccbd45defa496f25a"
+  integrity sha512-Z957sr0RpP2h9JzV1c2SF9PoZuvWocLE8cmy9PgaQBZcrlegF8ZjOcKSQ2L3+hinwwVP+kvdywLiZxPA5WnO+Q==
 
 "@pooltogether/owner-manager-contracts@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
- Resolves majority of the `Cannot convert undefined or null to object` errors stemming from RPC errors (Binance...).
- Resolves `Cannot read properties of undefined (reading '0x0cEC1A91...` errors stemming from CoinGecko API failures when fetching LP token prices.
- Silently logs `AbortError: The play() request was interrupted by a call to pause()` when the browser auto pauses videos.
- Resolves `Cannot read properties of undefined (reading '0x....)` when reading a users checked draws on the prizes page after switching between accounts.