### PR TITLE
Fixed Router Race Condition on Account Page

### DIFF
--- a/src/pages/account/[usersAddress].tsx
+++ b/src/pages/account/[usersAddress].tsx
@@ -14,10 +14,8 @@ export default function IndexPage() {
   const { usersAddress } = router.query
 
   useEffect(() => {
-    if (router.isReady) {
-      if (Array.isArray(usersAddress) || !isAddress(usersAddress)) {
-        router.replace(`/`)
-      }
+    if (router.isReady && (Array.isArray(usersAddress) || !isAddress(usersAddress))) {
+      router.replace(`/`)
     }
   }, [usersAddress, router])
 

--- a/src/pages/account/[usersAddress].tsx
+++ b/src/pages/account/[usersAddress].tsx
@@ -14,8 +14,10 @@ export default function IndexPage() {
   const { usersAddress } = router.query
 
   useEffect(() => {
-    if (Array.isArray(usersAddress) || !isAddress(usersAddress)) {
-      router.replace(`/`)
+    if (router.isReady) {
+      if (Array.isArray(usersAddress) || !isAddress(usersAddress)) {
+        router.replace(`/`)
+      }
     }
   }, [usersAddress, router])
 


### PR DESCRIPTION
The redirection bug on the account page was caused by the `useEffect()` triggering before the Next router was fully initialized/ready.

The effect will re-trigger once the router is ready (which is before the page fully loads), so there is no issues with skipping the check on its first run-through.

Had a quick glance around the other instances of the router on other pages, and this doesn't seem likely to be an issue anywhere else.