### PR TITLE
Fixed Deposit Flow Form Resets

### DIFF
--- a/src/components/Modal/DepositModal/DepositView.tsx
+++ b/src/components/Modal/DepositModal/DepositView.tsx
@@ -12,12 +12,16 @@ export const DepositView: React.FC<
   {
     depositAmount: Amount
     setDepositAmount: (amount: Amount) => void
+    formAmount: string
+    setFormAmount: (amount: string) => void
     depositTransaction?: Transaction
   } & ViewProps
 > = (props) => {
   const {
     depositAmount,
     setDepositAmount,
+    formAmount,
+    setFormAmount,
     depositTransaction,
     setSelectedViewId,
     ...remainingProps
@@ -34,8 +38,9 @@ export const DepositView: React.FC<
       onSubmit={() => setSelectedViewId(ViewIds.reviewTransaction)}
       chainId={prizePool.chainId}
       token={tokens?.token}
-      defaultValue={depositAmount?.amount}
+      defaultValue={formAmount}
       setDepositAmount={setDepositAmount}
+      setFormAmount={setFormAmount}
     />
   )
 }

--- a/src/components/Modal/DepositModal/index.tsx
+++ b/src/components/Modal/DepositModal/index.tsx
@@ -28,6 +28,7 @@ export const DepositModal: React.FC<{
   const { isOpen, initialViewId, closeModal } = props
   const [selectedViewId, setSelectedViewId] = useState<string | number>(initialViewId)
   const [depositAmount, setDepositAmount] = useState<Amount>()
+  const [formAmount, setFormAmount] = useState<string>()
   const { chainId } = useSelectedChainId()
   const [depositTransactionId, setDepositTransactionId] = useState('')
   const depositTransaction = useTransaction(depositTransactionId)
@@ -94,6 +95,8 @@ export const DepositModal: React.FC<{
       depositTransaction={depositTransaction}
       depositAmount={depositAmount}
       setDepositAmount={setDepositAmount}
+      formAmount={formAmount}
+      setFormAmount={setFormAmount}
       // reviewView
       sendDepositTransaction={sendDepositTransaction}
       clearDepositTransaction={() => setDepositTransactionId('')}

--- a/src/components/ModalViews/DepositView/index.tsx
+++ b/src/components/ModalViews/DepositView/index.tsx
@@ -21,7 +21,9 @@ import { DepositInfoBox } from './DepositInfoBox'
 export const DepositView: React.FC<
   {
     depositAmount: Amount
+    defaultValue: string
     setDepositAmount: (amount: Amount) => void
+    setFormAmount: (amount: string) => void
     transaction?: Transaction
     formKey: string
     connectWallet?: () => void
@@ -30,7 +32,9 @@ export const DepositView: React.FC<
 > = (props) => {
   const {
     depositAmount,
+    defaultValue,
     setDepositAmount,
+    setFormAmount,
     transaction,
     formKey,
     connectWallet,
@@ -50,6 +54,9 @@ export const DepositView: React.FC<
       formKey={formKey}
       connectWallet={connectWallet}
       useValidationRules={useValidationRules}
+      handleChange={(values: TokenAmountFormValues) => {
+        setFormAmount(values[formKey].toString())
+      }}
       handleSubmit={(values: TokenAmountFormValues) => {
         setDepositAmount(getAmount(values[formKey], tokens?.token.decimals))
         onSubmit?.()
@@ -67,7 +74,7 @@ export const DepositView: React.FC<
       ]}
       chainId={prizePool.chainId}
       token={tokens?.token}
-      defaultValue={depositAmount?.amount}
+      defaultValue={defaultValue}
     />
   )
 }

--- a/src/components/ModalViews/TokenAmountInputFormView/index.tsx
+++ b/src/components/ModalViews/TokenAmountInputFormView/index.tsx
@@ -19,10 +19,10 @@ export interface TokenAmountInputFormViewProps
   formKey: string
   submitButtonContent?: React.ReactNode
   defaultValue?: string
+  handleChange?: (values: TokenAmountFormValues) => void
   handleSubmit: (values: TokenAmountFormValues) => void
 }
 
-// TODO: Add amount to query params so an input amount persists after connecting a wallet
 export const TokenAmountInputFormView: React.FC<TokenAmountInputFormViewProps> = (props) => {
   const {
     chainId,
@@ -34,6 +34,7 @@ export const TokenAmountInputFormView: React.FC<TokenAmountInputFormViewProps> =
     connectWallet,
     submitButtonContent,
     children,
+    handleChange,
     handleSubmit: _handleSubmit,
     defaultValue
   } = props
@@ -53,6 +54,7 @@ export const TokenAmountInputFormView: React.FC<TokenAmountInputFormViewProps> =
   return (
     <FormProvider {...methods}>
       <form
+        onChange={() => handleChange && handleChange(methods.getValues())}
         onSubmit={methods.handleSubmit(_handleSubmit)}
         className='flex w-full h-full flex-col space-y-6'
       >

--- a/src/views/Account/V4DepositList/BalanceModal/DepositView.tsx
+++ b/src/views/Account/V4DepositList/BalanceModal/DepositView.tsx
@@ -12,12 +12,16 @@ export const DepositView: React.FC<
   {
     depositAmount: Amount
     setDepositAmount: (amount: Amount) => void
+    formAmount: string
+    setFormAmount: (amount: string) => void
     depositTransaction?: Transaction
   } & ViewProps
 > = (props) => {
   const {
     depositAmount,
     setDepositAmount,
+    formAmount,
+    setFormAmount,
     depositTransaction,
     setSelectedViewId,
     ...remainingProps
@@ -34,8 +38,9 @@ export const DepositView: React.FC<
       onSubmit={() => setSelectedViewId(ViewIds.depositReview)}
       chainId={prizePool.chainId}
       token={tokens?.token}
-      defaultValue={depositAmount?.amount}
+      defaultValue={formAmount}
       setDepositAmount={setDepositAmount}
+      setFormAmount={setFormAmount}
     />
   )
 }

--- a/src/views/Account/V4DepositList/BalanceModal/index.tsx
+++ b/src/views/Account/V4DepositList/BalanceModal/index.tsx
@@ -37,6 +37,7 @@ export const BalanceModal: React.FC<{
 }> = (props) => {
   const { isOpen, closeModal: _closeModal } = props
   const [depositAmount, setDepositAmount] = useState<Amount>()
+  const [formAmount, setFormAmount] = useState<string>()
   const [withdrawAmount, setWithdrawAmount] = useState<Amount>()
   const { chainId } = useSelectedChainId()
   const { data: tokenData } = useSelectedPrizePoolTokens()
@@ -135,6 +136,8 @@ export const BalanceModal: React.FC<{
       token={tokenData?.token}
       depositTransaction={depositTransaction}
       setDepositAmount={setDepositAmount}
+      formAmount={formAmount}
+      setFormAmount={setFormAmount}
       clearDepositTransaction={() => setDepositTransactionId('')}
       // DepositReviewView
       depositAmount={depositAmount}

--- a/src/views/Deposit/DepositTrigger/DepositModal/DepositView.tsx
+++ b/src/views/Deposit/DepositTrigger/DepositModal/DepositView.tsx
@@ -12,12 +12,16 @@ export const DepositView: React.FC<
   {
     depositAmount: Amount
     setDepositAmount: (amount: Amount) => void
+    formAmount: string
+    setFormAmount: (amount: string) => void
     depositTransaction?: Transaction
   } & ViewProps
 > = (props) => {
   const {
     depositAmount,
     setDepositAmount,
+    formAmount,
+    setFormAmount,
     depositTransaction,
     setSelectedViewId,
     ...remainingProps
@@ -34,8 +38,9 @@ export const DepositView: React.FC<
       onSubmit={() => setSelectedViewId(ViewIds.reviewTransaction)}
       chainId={prizePool.chainId}
       token={tokens?.token}
-      defaultValue={depositAmount?.amount}
+      defaultValue={formAmount}
       setDepositAmount={setDepositAmount}
+      setFormAmount={setFormAmount}
     />
   )
 }

--- a/src/views/Deposit/DepositTrigger/DepositModal/index.tsx
+++ b/src/views/Deposit/DepositTrigger/DepositModal/index.tsx
@@ -34,6 +34,7 @@ export const DepositModal: React.FC<{
   const { isOpen, initialViewId, closeModal } = props
   const [selectedViewId, setSelectedViewId] = useState<string | number>(initialViewId)
   const [depositAmount, setDepositAmount] = useState<Amount>()
+  const [formAmount, setFormAmount] = useState<string>()
   const { chainId } = useSelectedChainId()
   const [depositTransactionId, setDepositTransactionId] = useState('')
   const depositTransaction = useTransaction(depositTransactionId)
@@ -118,6 +119,8 @@ export const DepositModal: React.FC<{
       depositTransaction={depositTransaction}
       depositAmount={depositAmount}
       setDepositAmount={setDepositAmount}
+      formAmount={formAmount}
+      setFormAmount={setFormAmount}
       // reviewView
       sendDepositTransaction={sendDepositTransaction}
       clearDepositTransaction={() => setDepositTransactionId('')}


### PR DESCRIPTION
The main change was made to `TokenAmountInputFormView`, where there is now an optional `handleChange` prop that passes any value change in the form upwards to its parent component. This way we can manage these changes differently in different scenarios, or just ignore it altogether due to it being optional. This seemed a bit cleaner than utilizing query params.

The second change is to `DepositView`, where the `defaultValue` is now the amount the user had previously left the form at (`formAmount`).

I've updated all the deposit modals that utilize `DepositView` to pass down the `formAmount` state.