### PR TITLE
Added Active Balance to Account Header

### DIFF
--- a/src/views/Account/AccountCard/index.tsx
+++ b/src/views/Account/AccountCard/index.tsx
@@ -2,7 +2,7 @@ import { TransparentDiv } from '@components/TransparentDiv'
 import { useUsersTotalBalances } from '@hooks/useUsersTotalBalances'
 import { useUsersPrizePoolNetworkOdds } from '@hooks/v4/PrizePoolNetwork/useUsersPrizePoolNetworkOdds'
 import { useAllUsersPrizePoolTwabs } from '@hooks/v4/PrizePool/useUsersPrizePoolTwab'
-import { ThemedClipSpinner, CountUp } from '@pooltogether/react-components'
+import { ThemedClipSpinner, CountUp, Tooltip } from '@pooltogether/react-components'
 import { shorten, formatCurrencyNumberForDisplay } from '@pooltogether/utilities'
 import { unionProbabilities } from '@utils/unionProbabilities'
 import classNames from 'classnames'
@@ -119,8 +119,16 @@ export const ActiveBalance: React.FC<{ value: string }> = (props) => {
   const { value } = props
   const { t } = useTranslation()
   return (
-    <span className='font-semibold text-xs'>
-      {t('active')}:&nbsp;{formatCurrencyNumberForDisplay(value, 'usd', { hideZeroes: true })}
+    <span className='flex items-center gap-1 font-semibold text-xs'>
+      <span className='opacity-80'>{t('active')}:</span>
+      <span className='opacity-80'>
+        {formatCurrencyNumberForDisplay(value, 'usd', { hideZeroes: true })}
+      </span>
+      <Tooltip
+        id={`activeBalanceTooltip`}
+        iconClassName='opacity-80'
+        tip={t('activeBalanceTooltip')}
+      />
     </span>
   )
 }

--- a/src/views/Account/AccountCard/index.tsx
+++ b/src/views/Account/AccountCard/index.tsx
@@ -3,7 +3,7 @@ import { useUsersTotalBalances } from '@hooks/useUsersTotalBalances'
 import { useUsersPrizePoolNetworkOdds } from '@hooks/v4/PrizePoolNetwork/useUsersPrizePoolNetworkOdds'
 import { useAllUsersPrizePoolTwabs } from '@hooks/v4/PrizePool/useUsersPrizePoolTwab'
 import { ThemedClipSpinner, CountUp } from '@pooltogether/react-components'
-import { shorten } from '@pooltogether/utilities'
+import { shorten, formatCurrencyNumberForDisplay } from '@pooltogether/utilities'
 import { unionProbabilities } from '@utils/unionProbabilities'
 import classNames from 'classnames'
 import FeatherIcon from 'feather-icons-react'
@@ -88,7 +88,7 @@ const TotalBalance: React.FC<{
         activeBalance &&
         isFullyFetched &&
         Number(activeBalance.amount) !== balancesData.totalV4Balance && (
-          <ActiveBalance value={Number(activeBalance.amount)} />
+          <ActiveBalance value={activeBalance.amount} />
         )}
     </a>
   )
@@ -115,13 +115,12 @@ export const TotalBalanceAmount: React.FC<{ usersAddress: string }> = (props) =>
   return <CountUp countTo={Number(balancesData?.totalV4Balance)} />
 }
 
-export const ActiveBalance: React.FC<{ value: number }> = (props) => {
+export const ActiveBalance: React.FC<{ value: string }> = (props) => {
   const { value } = props
   const { t } = useTranslation()
   return (
     <span className='font-semibold text-xs'>
-      {t('active')}:&nbsp;$
-      <CountUp countTo={value} />
+      {t('active')}:&nbsp;{formatCurrencyNumberForDisplay(value, 'usd', { hideZeroes: true })}
     </span>
   )
 }

--- a/src/views/Account/index.tsx
+++ b/src/views/Account/index.tsx
@@ -54,7 +54,7 @@ export const AccountUI = (props) => {
   return (
     <PagePadding className='grid gap-4 grid-cols-1 sm:grid-cols-3'>
       <div className='sm:col-span-2 space-y-4'>
-        <AccountCard usersAddress={usersAddress} />
+        <AccountCard usersAddress={usersAddress} showActive />
         <Card>
           <V4DepositList />
           <DelegationList />

--- a/src/views/SimpleAccount/index.tsx
+++ b/src/views/SimpleAccount/index.tsx
@@ -15,7 +15,7 @@ export const SimpleAccountUI = (props: { usersAddress: string }) => {
   return (
     <PagePadding className='grid gap-4 grid-cols-1 sm:grid-cols-3'>
       <div className='sm:col-span-2 space-y-4'>
-        <AccountCard usersAddress={usersAddress} showAddress />
+        <AccountCard usersAddress={usersAddress} showAddress showActive />
         <Card>
           <SimpleV4DepositList usersAddress={usersAddress} />
           <SimpleV3DepositList usersAddress={usersAddress} />


### PR DESCRIPTION
If the user's active balance is different from their deposited balance, the account page will now display their active balance.

For example, this lucky guy/gal just got delegated $50k from the No Loss November event:

![image](https://user-images.githubusercontent.com/22108522/200401347-952fec32-370a-4155-9451-7ae8b0e4605d.png)

The balance will be displayed (if necessary) once the deposited balance is fully calculated, and animates upwards in the same manner.

If we want to disable this at any point, we can just remove `showActive` from any page/view/component calling `AccountCard`.