### PR TITLE
Displaying Pool w/ Lowest Network Fees

### DIFF
--- a/src/components/BrowsePrizePools/RecommendedPrizePools.tsx
+++ b/src/components/BrowsePrizePools/RecommendedPrizePools.tsx
@@ -2,7 +2,7 @@ import { PrizePool } from '@pooltogether/v4-client-js'
 import classNames from 'classnames'
 import { TopPoolByAvgPrizeValue } from './TopPool/TopPoolByAvgPrizeValue'
 import { TopPoolByOdds } from './TopPool/TopPoolByOdds'
-import { TopPoolByPrizes } from './TopPool/TopPoolByPrizes'
+import { TopPoolByGas } from './TopPool/TopPoolByGas'
 import { TopPoolByTvl } from './TopPool/TopPoolByTvl'
 
 export const RecommendedPrizePools = (props: {
@@ -29,7 +29,7 @@ export const RecommendedPrizePools = (props: {
         onPrizePoolSelect={onPrizePoolSelect}
         className='flex flex-col justify-between h-full'
       />
-      <TopPoolByPrizes
+      <TopPoolByGas
         onPrizePoolSelect={onPrizePoolSelect}
         className='flex flex-col justify-between h-full'
       />

--- a/src/components/BrowsePrizePools/TopPool/TopPoolByGas.tsx
+++ b/src/components/BrowsePrizePools/TopPool/TopPoolByGas.tsx
@@ -1,0 +1,35 @@
+import { useSelectedPrizePoolAddress } from '@hooks/useSelectedPrizePoolAddress'
+import { usePrizePool } from '@hooks/v4/PrizePool/usePrizePool'
+import { PrizePool } from '@pooltogether/v4-client-js'
+import { useTranslation } from 'next-i18next'
+import { TopPool } from '.'
+
+export const TopPoolByGas: React.FC<{
+  className?: string
+  onPrizePoolSelect?: (prizePool: PrizePool) => void
+}> = (props) => {
+  const { t } = useTranslation()
+  const { onPrizePoolSelect, className } = props
+  const { setSelectedPrizePoolAddress } = useSelectedPrizePoolAddress()
+
+  // This is currently hardcoded to Polygon's V4 USDC pool.
+  // Once there are more pools per chain this will have to be refactored.
+  const prizePool = usePrizePool(137, '0x19DE635fb3678D8B8154E37d8C9Cdf182Fe84E60')
+
+  return (
+    <TopPool
+      className={className}
+      isFetched={true}
+      title={t('lowestNetworkFees')}
+      description={t('lowestNetworkFeesDescription')}
+      prizePool={prizePool}
+      onClick={async (prizePool) => {
+        if (!!onPrizePoolSelect) {
+          onPrizePoolSelect(prizePool)
+        } else {
+          setSelectedPrizePoolAddress(prizePool)
+        }
+      }}
+    />
+  )
+}

--- a/src/components/BrowsePrizePools/TopPool/TopPoolByGas.tsx
+++ b/src/components/BrowsePrizePools/TopPool/TopPoolByGas.tsx
@@ -1,6 +1,7 @@
 import { useSelectedPrizePoolAddress } from '@hooks/useSelectedPrizePoolAddress'
 import { usePrizePool } from '@hooks/v4/PrizePool/usePrizePool'
 import { PrizePool } from '@pooltogether/v4-client-js'
+import { CHAIN_ID } from '@pooltogether/wallet-connection'
 import { useTranslation } from 'next-i18next'
 import { TopPool } from '.'
 
@@ -14,7 +15,7 @@ export const TopPoolByGas: React.FC<{
 
   // This is currently hardcoded to Polygon's V4 USDC pool.
   // Once there are more pools per chain this will have to be refactored.
-  const prizePool = usePrizePool(137, '0x19DE635fb3678D8B8154E37d8C9Cdf182Fe84E60')
+  const prizePool = usePrizePool(CHAIN_ID.polygon, '0x19DE635fb3678D8B8154E37d8C9Cdf182Fe84E60')
 
   return (
     <TopPool


### PR DESCRIPTION
- Added `TopPoolByGas` to display the pool with lowest expected transaction cost.
- Switched recommended pools display to show those pools instead of "most prizes".

This component is hard-coded to Polygon's V4 USDC pool as it is by far the network with lowest fees.