### PR TITLE
ExplorePrizePoolsHeader: Styled Dismissable Info + Buttons

### DIFF
--- a/src/components/ModalViews/ExplorePrizePoolsView/ExplorePrizePoolsHeader.tsx
+++ b/src/components/ModalViews/ExplorePrizePoolsView/ExplorePrizePoolsHeader.tsx
@@ -15,7 +15,7 @@ export const ExplorePrizePoolsHeader = () => {
         size={ButtonSize.sm}
         theme={ButtonTheme.transparent}
       >
-        How does this work?
+        {t('howDoesThisWork')}
       </Button>
     )
   }
@@ -34,7 +34,7 @@ export const ExplorePrizePoolsHeader = () => {
         size={ButtonSize.sm}
         theme={ButtonTheme.transparent}
       >
-        Dismiss
+        {t('dismiss')}
       </Button>
     </div>
   )

--- a/src/components/ModalViews/ExplorePrizePoolsView/ExplorePrizePoolsHeader.tsx
+++ b/src/components/ModalViews/ExplorePrizePoolsView/ExplorePrizePoolsHeader.tsx
@@ -1,40 +1,41 @@
 import { PoolTogetherExplainerWithStats } from '@components/PoolTogetherExplainerWithStats'
-import { ExternalLink, LinkTheme } from '@pooltogether/react-components'
+import { useCachedDismiss } from '@hooks/useCachedDismiss'
+import { Button, ButtonSize, ButtonTheme, ExternalLink } from '@pooltogether/react-components'
 import { useTranslation } from 'next-i18next'
 
 export const ExplorePrizePoolsHeader = () => {
   const { t } = useTranslation()
+  const { dismissed, dismiss, enable } = useCachedDismiss('explore-prize-pools-header')
+
+  if (dismissed) {
+    return (
+      <Button
+        onClick={enable}
+        className='mb-6 opacity-75 hover:opacity-100'
+        size={ButtonSize.sm}
+        theme={ButtonTheme.transparent}
+      >
+        How does this work?
+      </Button>
+    )
+  }
+
   return (
-    <div className='mb-8 sm:mb-12 opacity-80'>
-      <PoolTogetherExplainerWithStats />{' '}
-      <ExternalLink underline href={'https://docs.pooltogether.com/welcome/faq'}>
-        {t('learnMore')}
-      </ExternalLink>
+    <div className='flex flex-col sm:flex-row gap-2 sm:gap-4 mb-8 sm:mb-8 px-3 py-2 bg-white bg-opacity-100 dark:bg-actually-black dark:bg-opacity-10 rounded-lg'>
+      <div className='opacity-80'>
+        <PoolTogetherExplainerWithStats />{' '}
+        <ExternalLink underline href={'https://docs.pooltogether.com/welcome/faq'}>
+          {t('learnMore')}
+        </ExternalLink>
+      </div>
+      <Button
+        onClick={dismiss}
+        className='mt-auto ml-auto flex-shrink-0 opacity-75 hover:opacity-100'
+        size={ButtonSize.sm}
+        theme={ButtonTheme.transparent}
+      >
+        Dismiss
+      </Button>
     </div>
   )
-
-  // TODO: Make this dismissable info box prettier
-  // const { dismissed, dismiss, enable } = useCachedDismiss('explore-prize-pools-header')
-  // if (dismissed) {
-  //   return (
-  //     <button onClick={enable} className='mb-4 opacity-75 hover:opacity-100'>
-  //       How does this work?
-  //     </button>
-  //   )
-  // }
-  // return (
-  //   <div className='mb-12'>
-  //     <div className='opacity-80'>
-  //       <PoolTogetherExplainerWithStats />
-  //     </div>
-  //     <Button
-  //       onClick={dismiss}
-  //       className='ml-auto'
-  //       size={ButtonSize.sm}
-  //       theme={ButtonTheme.transparent}
-  //     >
-  //       Dismiss
-  //     </Button>
-  //   </div>
-  // )
 }


### PR DESCRIPTION
- Styled explainer section for desktop and mobile.
- The section can now be dismissed and brought back up through buttons.

By default, the explanation will be displayed with a 'Dismiss' button in its bottom-right. If clicked, the explanation will be hidden and instead a "How does this work?" button will be displayed instead. Was debating the position of this button, but it looks decent left-aligned as of now imo.

### Desktop:

![image](https://user-images.githubusercontent.com/22108522/201185971-7691d687-4603-4de8-814a-bba05d2f2c50.png)

![image](https://user-images.githubusercontent.com/22108522/201186018-69ac3318-66fe-4c07-809f-fd14e8ce1306.png)

### Mobile:

![image](https://user-images.githubusercontent.com/22108522/201186082-cbb89689-5b32-4912-9e96-3edad8d6d229.png)

![image](https://user-images.githubusercontent.com/22108522/201186108-4d9b847f-d759-467f-b83d-15eec0478274.png)
