### PR TITLE
Simplified Prize Count

### DIFF
--- a/src/views/Deposit/PrizePoolNetworkCarousel/UpcomingPrize.tsx
+++ b/src/views/Deposit/PrizePoolNetworkCarousel/UpcomingPrize.tsx
@@ -67,27 +67,29 @@ const AmountOfPrizes = () => {
   let amountString:
     | 'lotsOfPrizesEveryWeek'
     | 'hundredsOfPrizesEveryWeek'
-    | 'thousandsOfPrizesEveryWeek' = 'thousandsOfPrizesEveryWeek'
+    | 'thousandsOfPrizesEveryWeek' = 'lotsOfPrizesEveryWeek'
   if (isFetched) {
     if (weeklyAmountOfPrizes > 1000) {
       amountString = 'thousandsOfPrizesEveryWeek'
     } else if (weeklyAmountOfPrizes > 100) {
       amountString = 'hundredsOfPrizesEveryWeek'
-    } else {
-      amountString = 'lotsOfPrizesEveryWeek'
     }
   }
 
   return (
-    <div className='font-semibold text-xs xs:text-lg mt-2 mb-1 text-pt-purple-darkest dark:text-pt-purple-lightest text-opacity-80 dark:text-opacity-90'>
+    <div
+      className={classNames(
+        'font-semibold text-xs xs:text-lg mt-2 mb-1 text-pt-purple-darkest dark:text-pt-purple-lightest text-opacity-80 dark:text-opacity-90',
+        { 'opacity-0': !isFetched }
+      )}
+    >
       <Trans
         i18nKey={amountString}
         components={{
           style: (
             <span
               className={classNames('transition text-gradient-magenta', {
-                'text-opacity-100': isFetched,
-                'opacity-50 animate-pulse': !isFetched
+                'text-opacity-100': isFetched
               })}
             />
           )

--- a/src/views/Deposit/PrizePoolNetworkCarousel/UpcomingPrize.tsx
+++ b/src/views/Deposit/PrizePoolNetworkCarousel/UpcomingPrize.tsx
@@ -44,8 +44,9 @@ export const UpcomingPrize: React.FC<{ className?: string }> = (props) => {
   )
 }
 
-const AmountOfPrizes = (props) => {
+const AmountOfPrizes = () => {
   const queryResults = useAllPrizePoolExpectedPrizes()
+
   const { isFetched, amountOfPrizes } = useMemo(() => {
     const isFetched = queryResults.some(({ isFetched }) => isFetched)
     if (!isFetched) {
@@ -61,10 +62,26 @@ const AmountOfPrizes = (props) => {
     }
   }, [queryResults])
 
+  const weeklyAmountOfPrizes = amountOfPrizes * 7
+
+  let amountString:
+    | 'lotsOfPrizesEveryWeek'
+    | 'hundredsOfPrizesEveryWeek'
+    | 'thousandsOfPrizesEveryWeek' = 'thousandsOfPrizesEveryWeek'
+  if (isFetched) {
+    if (weeklyAmountOfPrizes > 1000) {
+      amountString = 'thousandsOfPrizesEveryWeek'
+    } else if (weeklyAmountOfPrizes > 100) {
+      amountString = 'hundredsOfPrizesEveryWeek'
+    } else {
+      amountString = 'lotsOfPrizesEveryWeek'
+    }
+  }
+
   return (
     <div className='font-semibold text-xs xs:text-lg mt-2 mb-1 text-pt-purple-darkest dark:text-pt-purple-lightest text-opacity-80 dark:text-opacity-90'>
       <Trans
-        i18nKey={'prizesEveryWeek'}
+        i18nKey={amountString}
         components={{
           style: (
             <span
@@ -73,8 +90,7 @@ const AmountOfPrizes = (props) => {
                 'opacity-50 animate-pulse': !isFetched
               })}
             />
-          ),
-          amount: <CountUp countFrom={0} countTo={amountOfPrizes * 7} decimals={0} />
+          )
         }}
       />
     </div>


### PR DESCRIPTION
This PR makes it so that a word is used instead of the exact number of prizes on the main carousel.

![image](https://user-images.githubusercontent.com/22108522/208142375-9be542bd-746b-4839-8152-9a24dadea021.png)

I've gone with "Lots of Prizes", "Hundreds of Prizes" and "Thousands of Prizes" for now.