### PR TITLE
Prize Frequency Breakdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@pooltogether/hooks": "^2.0.0-beta.6",
     "@pooltogether/pooltogether-contracts": "^3.4.4",
     "@pooltogether/react-components": "2.0.2",
-    "@pooltogether/utilities": "^0.6.7",
+    "@pooltogether/utilities": "^0.7.0",
     "@pooltogether/v4-client-js": "^0.16.1",
     "@pooltogether/v4-pool-data": "1.11.0-beta.3",
     "@pooltogether/v4-twab-delegator-js": "0.2.2",

--- a/src/components/ModalViews/DepositView/ExpectedPrizeBreakdown.tsx
+++ b/src/components/ModalViews/DepositView/ExpectedPrizeBreakdown.tsx
@@ -137,7 +137,7 @@ const OddsForTier = (props: { expectedNumberOfPrizes: number; amountToDeposit: A
   )
 }
 
-const PrizeTableCell = (props: { index: number } & JSX.IntrinsicElements['div']) => (
+export const PrizeTableCell = (props: { index: number } & JSX.IntrinsicElements['div']) => (
   <div
     {...props}
     className={classnames(props.className, 'text-sm xs:text-lg leading-none w-full', {

--- a/src/components/ModalViews/DepositView/PrizeFrequencyBreakdown.tsx
+++ b/src/components/ModalViews/DepositView/PrizeFrequencyBreakdown.tsx
@@ -20,6 +20,7 @@ export const PrizeFrequencyBreakdown = (props: { prizeTier: PrizeTierV2; classNa
   const { data: prizeData, isFetched: isPrizesFetched } = usePrizePoolPrizes(prizePool)
   const { data: ticketSupply, isFetched: isTicketSupplyFetched } =
     usePrizePoolTicketTwabTotalSupply(prizePool)
+  const { t } = useTranslation()
 
   const isFetched = isPrizesFetched && isTicketSupplyFetched
 
@@ -45,8 +46,6 @@ export const PrizeFrequencyBreakdown = (props: { prizeTier: PrizeTierV2; classNa
     }
   }, [isFetched, prizeTier, ticketSupply, prizeData])
 
-  // TODO: localization
-
   return (
     <TransparentDiv
       className={classNames(
@@ -54,10 +53,11 @@ export const PrizeFrequencyBreakdown = (props: { prizeTier: PrizeTierV2; classNa
         className
       )}
     >
-      <span className='mb-2 font-bold'>Estimated Prize Frequency Breakdown</span>
+      <span className='font-bold'>{t('estimatedPrizeFrequencyBreakdown')}</span>
+      <span className='mb-2 text-xxxs opacity-60'>{t('prizeFrequencyBreakdownDescription')}</span>
       <div className='grid grid-cols-2 mb-2'>
-        <PrizeTableHeader>Prize Value</PrizeTableHeader>
-        <PrizeTableHeader>Award Time</PrizeTableHeader>
+        <PrizeTableHeader>{t('prizeValue')}</PrizeTableHeader>
+        <PrizeTableHeader>{t('awardTime')}</PrizeTableHeader>
       </div>
 
       {!isFetched ? (

--- a/src/components/ModalViews/DepositView/PrizeFrequencyBreakdown.tsx
+++ b/src/components/ModalViews/DepositView/PrizeFrequencyBreakdown.tsx
@@ -1,6 +1,5 @@
 import { TransparentDiv } from '@components/TransparentDiv'
-import { usePrizePoolPrizes } from '@hooks/v4/PrizePool/usePrizePoolPrizes'
-import { usePrizePoolTicketTwabTotalSupply } from '@hooks/v4/PrizePool/usePrizePoolTicketTwabTotalSupply'
+import { usePrizePoolExpectedPrizes } from '@hooks/v4/PrizePool/usePrizePoolExpectedPrizes'
 import { useSelectedPrizePool } from '@hooks/v4/PrizePool/useSelectedPrizePool'
 import { Amount } from '@pooltogether/hooks'
 import {
@@ -8,43 +7,16 @@ import {
   formatDailyCountToFrequency
 } from '@pooltogether/utilities'
 import { TimeUnit } from '@pooltogether/utilities/dist/types'
-import { PrizeTierV2 } from '@pooltogether/v4-utils-js'
 import classNames from 'classnames'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LoadingPrizeRow, PrizeTableCell, PrizeTableHeader } from './ExpectedPrizeBreakdown'
 
-export const PrizeFrequencyBreakdown = (props: { prizeTier: PrizeTierV2; className?: string }) => {
-  const { prizeTier, className } = props
+export const PrizeFrequencyBreakdown = (props: { className?: string }) => {
+  const { className } = props
   const prizePool = useSelectedPrizePool()
-  const { data: prizeData, isFetched: isPrizesFetched } = usePrizePoolPrizes(prizePool)
-  const { data: ticketSupply, isFetched: isTicketSupplyFetched } =
-    usePrizePoolTicketTwabTotalSupply(prizePool)
+  const { data: prizeData, isFetched } = usePrizePoolExpectedPrizes(prizePool)
   const { t } = useTranslation()
-
-  const isFetched = isPrizesFetched && isTicketSupplyFetched
-
-  const calculateDprMultiplier = (
-    rawDpr: number,
-    ticketSupplyAmount: string,
-    totalPrizeAmount: string
-  ) => {
-    const dpr = rawDpr / 10 ** 9
-    const tvl = parseFloat(ticketSupplyAmount)
-    const prizes = parseFloat(totalPrizeAmount)
-    return (dpr * tvl) / prizes
-  }
-
-  const prizeChances = useMemo(() => {
-    if (isFetched) {
-      const dprMultiplier = calculateDprMultiplier(
-        prizeTier.dpr,
-        ticketSupply.amount.amount,
-        prizeData.totalValueOfPrizes.amount
-      )
-      return prizeData.numberOfPrizesByTier.map((numPrizes) => numPrizes * dprMultiplier)
-    }
-  }, [isFetched, prizeTier, ticketSupply, prizeData])
 
   return (
     <TransparentDiv
@@ -73,7 +45,7 @@ export const PrizeFrequencyBreakdown = (props: { prizeTier: PrizeTierV2; classNa
               key={`prize_freq_row_${i}`}
               index={i}
               prizeValue={prizeData.valueOfPrizesByTier[i]}
-              prizeChance={prizeChances[i]}
+              prizeChance={prizeData.expectedNumberOfPrizesByTier[i]}
             />
           ))}
         </ul>

--- a/src/components/ModalViews/DepositView/PrizeFrequencyBreakdown.tsx
+++ b/src/components/ModalViews/DepositView/PrizeFrequencyBreakdown.tsx
@@ -1,0 +1,151 @@
+import { TransparentDiv } from '@components/TransparentDiv'
+import { useFormTokenAmount } from '@hooks/useFormTokenAmount'
+import { usePrizePoolPrizes } from '@hooks/v4/PrizePool/usePrizePoolPrizes'
+import { usePrizePoolTicketTwabTotalSupply } from '@hooks/v4/PrizePool/usePrizePoolTicketTwabTotalSupply'
+import { useSelectedPrizePool } from '@hooks/v4/PrizePool/useSelectedPrizePool'
+import { useSelectedPrizePoolTokens } from '@hooks/v4/PrizePool/useSelectedPrizePoolTokens'
+import { Amount } from '@pooltogether/hooks'
+import {
+  formatCurrencyNumberForDisplay,
+  formatDailyCountToFrequency
+} from '@pooltogether/utilities'
+import { TimeUnit } from '@pooltogether/utilities/dist/types'
+import { PrizeTierV2 } from '@pooltogether/v4-utils-js'
+import classNames from 'classnames'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { LoadingPrizeRow, PrizeTableCell, PrizeTableHeader } from './ExpectedPrizeBreakdown'
+
+export const PrizeFrequencyBreakdown = (props: {
+  formKey: string
+  prizeTier: PrizeTierV2
+  className?: string
+}) => {
+  const { formKey, prizeTier, className } = props
+  const prizePool = useSelectedPrizePool()
+  const { data: prizeData, isFetched: isPrizesFetched } = usePrizePoolPrizes(prizePool)
+  const { data: ticketSupply, isFetched: isTicketSupplyFetched } =
+    usePrizePoolTicketTwabTotalSupply(prizePool)
+  const { data: tokens } = useSelectedPrizePoolTokens()
+  const amountToDeposit = useFormTokenAmount(formKey, tokens?.token)
+
+  const isFetched = isPrizesFetched && isTicketSupplyFetched
+
+  const calculateDprMultiplier = (
+    rawDpr: number,
+    ticketSupplyAmount: string,
+    totalPrizeAmount: string
+  ) => {
+    const dpr = rawDpr / 10 ** 9
+    const tvl = parseFloat(ticketSupplyAmount)
+    const prizes = parseFloat(totalPrizeAmount)
+    return (dpr * tvl) / prizes
+  }
+
+  const prizeChances = useMemo(() => {
+    if (isFetched) {
+      const dprMultiplier = calculateDprMultiplier(
+        prizeTier.dpr,
+        ticketSupply.amount.amount,
+        prizeData.totalValueOfPrizes.amount
+      )
+      return prizeData.numberOfPrizesByTier.map((numPrizes) => numPrizes * dprMultiplier)
+    }
+  }, [isFetched, prizeTier, ticketSupply, prizeData])
+
+  // TODO: localization
+
+  return (
+    <TransparentDiv
+      className={classNames(
+        'flex flex-col max-w-md text-center px-4 py-2 overflow-y-auto rounded-lg minimal-scrollbar max-h-56',
+        className
+      )}
+    >
+      <span className='mb-2 font-bold'>Prize Frequency Breakdown</span>
+      <div className='grid grid-cols-2 mb-2'>
+        <PrizeTableHeader>Prize Value</PrizeTableHeader>
+        <PrizeTableHeader>Estimated Award Time</PrizeTableHeader>
+      </div>
+
+      {!isFetched ? (
+        <>
+          <LoadingPrizeRow />
+          <LoadingPrizeRow />
+          <LoadingPrizeRow />
+        </>
+      ) : (
+        <ul className='grid grid-cols-2 gap-3'>
+          {prizeData.prizeTier?.tiers.map((_, i) => (
+            <PrizeFrequencyBreakdownTableRow
+              key={`prize_freq_row_${i}`}
+              index={i}
+              prizeValue={prizeData.valueOfPrizesByTier[i]}
+              prizeChance={prizeChances[i]}
+              amountToDeposit={amountToDeposit}
+            />
+          ))}
+        </ul>
+      )}
+    </TransparentDiv>
+  )
+}
+
+const PrizeFrequencyBreakdownTableRow = (props: {
+  index: number
+  prizeValue: Amount
+  prizeChance: number
+  amountToDeposit: Amount
+}) => {
+  const { index, prizeValue, prizeChance, amountToDeposit } = props
+
+  // This assumes there is one draw every day:
+  const prizeFrequency = formatDailyCountToFrequency(prizeChance)
+
+  if (prizeValue.amountUnformatted.isZero()) return null
+
+  return (
+    <>
+      <PrizeTableCell index={index}>
+        {formatCurrencyNumberForDisplay(prizeValue.amount, 'usd', {
+          hideZeroes: true
+        })}
+      </PrizeTableCell>
+      <PrizeTableCell index={index}>
+        <PrettyFrequencyForTier prizeFrequency={prizeFrequency} amountToDeposit={amountToDeposit} />
+      </PrizeTableCell>
+    </>
+  )
+}
+
+const PrettyFrequencyForTier = (props: {
+  prizeFrequency: { frequency: number; unit: TimeUnit }
+  amountToDeposit: Amount
+}) => {
+  const { prizeFrequency, amountToDeposit } = props
+  const { t } = useTranslation()
+
+  // TODO: take into account user deposit and show odds specifically for their deposit size
+
+  const prettyFrequencyString = useMemo(() => {
+    if (prizeFrequency.frequency !== 0) {
+      if (prizeFrequency.unit === 'day') {
+        if (prizeFrequency.frequency <= 1.5) {
+          return t('daily')
+        } else {
+          return t('everyNDays', { n: prizeFrequency.frequency.toFixed(0) })
+        }
+      } else if (prizeFrequency.unit === 'week') {
+        return t('everyNWeeks', { n: prizeFrequency.frequency.toFixed(0) })
+      } else if (prizeFrequency.unit === 'month') {
+        return t('everyNMonths', { n: prizeFrequency.frequency.toFixed(0) })
+      } else {
+        return t('everyNYears', { n: prizeFrequency.frequency.toFixed(0) })
+      }
+    } else {
+      return t('never')
+    }
+  }, [prizeFrequency])
+
+  return <>{prettyFrequencyString}</>
+}

--- a/src/components/ModalViews/DepositView/index.tsx
+++ b/src/components/ModalViews/DepositView/index.tsx
@@ -68,11 +68,7 @@ export const DepositView: React.FC<
     prizeTierData.prizeTier.dpr !== undefined
   ) {
     carouselChildren.push(
-      <PrizeFrequencyBreakdown
-        key='prize-freq-breakdown'
-        formKey={formKey}
-        prizeTier={prizeTierData.prizeTier}
-      />
+      <PrizeFrequencyBreakdown key='prize-freq-breakdown' prizeTier={prizeTierData.prizeTier} />
     )
   }
 

--- a/src/components/ModalViews/DepositView/index.tsx
+++ b/src/components/ModalViews/DepositView/index.tsx
@@ -6,12 +6,15 @@ import {
 import { useDepositValidationRules } from '@hooks/v4/PrizePool/useDepositValidationRules'
 import { useSelectedPrizePool } from '@hooks/v4/PrizePool/useSelectedPrizePool'
 import { useSelectedPrizePoolTokens } from '@hooks/v4/PrizePool/useSelectedPrizePoolTokens'
+import { useUpcomingPrizeTier } from '@hooks/v4/PrizePool/useUpcomingPrizeTier'
 import { Amount } from '@pooltogether/hooks'
 import { ViewProps } from '@pooltogether/react-components'
 import { getAmount } from '@pooltogether/utilities'
 import { Transaction } from '@pooltogether/wallet-connection'
+import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DepositInfoBox } from './DepositInfoBox'
+import { PrizeFrequencyBreakdown } from './PrizeFrequencyBreakdown'
 
 /**
  * Handles passing default values to the TokenAmountInputFormView for depositing into V4 prize pools.
@@ -43,9 +46,35 @@ export const DepositView: React.FC<
   } = props
   const prizePool = useSelectedPrizePool()
   const { data: tokens } = useSelectedPrizePoolTokens()
+  const { data: prizeTierData, isFetched: isPrizeTierFetched } = useUpcomingPrizeTier(prizePool)
   const { t } = useTranslation()
 
   const useValidationRules = () => useDepositValidationRules(prizePool)
+
+  const carouselChildren: ReactElement[] = [
+    <DepositInfoBox
+      key='deposit-info-box'
+      formKey={formKey}
+      transaction={transaction}
+      bgClassName='bg-white bg-opacity-100 dark:bg-actually-black dark:bg-opacity-10 transition-opacity'
+      errorBgClassName='bg-white bg-opacity-50 dark:bg-actually-black dark:bg-opacity-30 transition-opacity'
+    />,
+    <ExpectedPrizeBreakdown key='prize-breakdown' formKey={formKey} className='mx-auto' />
+  ]
+
+  if (
+    isPrizeTierFetched &&
+    'dpr' in prizeTierData.prizeTier &&
+    prizeTierData.prizeTier.dpr !== undefined
+  ) {
+    carouselChildren.push(
+      <PrizeFrequencyBreakdown
+        key='prize-freq-breakdown'
+        formKey={formKey}
+        prizeTier={prizeTierData.prizeTier}
+      />
+    )
+  }
 
   return (
     <TokenAmountInputFormView
@@ -61,17 +90,7 @@ export const DepositView: React.FC<
         setDepositAmount(getAmount(values[formKey], tokens?.token.decimals))
         onSubmit?.()
       }}
-      carouselChildren={[
-        <DepositInfoBox
-          key='deposit-info-box'
-          formKey={formKey}
-          transaction={transaction}
-          bgClassName='bg-white bg-opacity-100 dark:bg-actually-black dark:bg-opacity-10 transition-opacity'
-          errorBgClassName='bg-white bg-opacity-50 dark:bg-actually-black dark:bg-opacity-30 transition-opacity'
-        />,
-
-        <ExpectedPrizeBreakdown key='prize-breakdown' formKey={formKey} className='mx-auto' />
-      ]}
+      carouselChildren={carouselChildren}
       chainId={prizePool.chainId}
       token={tokens?.token}
       defaultValue={defaultValue}

--- a/src/components/ModalViews/DepositView/index.tsx
+++ b/src/components/ModalViews/DepositView/index.tsx
@@ -67,9 +67,7 @@ export const DepositView: React.FC<
     'dpr' in prizeTierData.prizeTier &&
     prizeTierData.prizeTier.dpr !== undefined
   ) {
-    carouselChildren.push(
-      <PrizeFrequencyBreakdown key='prize-freq-breakdown' prizeTier={prizeTierData.prizeTier} />
-    )
+    carouselChildren.push(<PrizeFrequencyBreakdown key='prize-freq-breakdown' />)
   }
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,10 +2337,10 @@
   resolved "https://registry.yarnpkg.com/@pooltogether/utilities/-/utilities-0.6.2.tgz#71a4e6dd56c6f0a03feea95b4f3a1b8eeee04329"
   integrity sha512-vGqf8wqdKbP3Sk0xsF8W6wkRJgyPEGCIyeH1YM3kPjzNn4mCMAc08tGlBtq0CvjkvaNwWgLAMv2/L7Jh//wbbw==
 
-"@pooltogether/utilities@^0.6.7":
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/@pooltogether/utilities/-/utilities-0.6.7.tgz#2a500cdd76999b08be2350583e90ee01d71b3c2c"
-  integrity sha512-i/gjNmzXIGr4iezKMR6a2bB6gaMa8/B9CvMw0o04X1qSS63ma2qAFxWUfwyLnKjUM1duqeVkbtW9FrUEIod4TA==
+"@pooltogether/utilities@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@pooltogether/utilities/-/utilities-0.7.0.tgz#2d9b14beb9ce25ec9fcf63091bb4623567406878"
+  integrity sha512-BSzMGG5/lFHvx8diZxQpkJ/yNOxqnMfimWpgs4AVQmdXAyn7NhfM8CJJ/17OnQ0I7qOCXqiZhQcQholEynSyRg==
 
 "@pooltogether/v4-client-js@^0.16.1":
   version "0.16.1"


### PR DESCRIPTION
This PR adds a third carousel item called "Estimated Prize Frequency Breakdown" in the deposit modal when applicable (PrizeTierHistoryV2 contracts).

![image](https://user-images.githubusercontent.com/22108522/208524989-25ffc644-320f-4656-b284-3db9d03ccd28.png)

The description shown is on Locize with a key of `prizeFrequencyBreakdownDescription` for any future changes/updates.

Some frequency calculations make use of the new `formatDailyCountToFrequency()` util function, and thus the `@pooltogether/utilities` package was bumped from `0.6.7` to `0.7.0`.

The carousel children on the main `index` file of `DepositView` by default include the pre-existing two items, and only include the new card if it notices that the `PrizeTier` object includes a `dpr` attribute.