### PR TITLE
Infinite Approval Toggle

### DIFF
--- a/src/components/ModalViews/ReviewTransactionView.tsx
+++ b/src/components/ModalViews/ReviewTransactionView.tsx
@@ -6,17 +6,9 @@ import { usePrizePoolTokens } from '@hooks/v4/PrizePool/usePrizePoolTokens'
 import { useSelectedPrizePool } from '@hooks/v4/PrizePool/useSelectedPrizePool'
 import { Amount, useTokenAllowance } from '@pooltogether/hooks'
 import { Button, ButtonRadius, ButtonTheme, ViewProps } from '@pooltogether/react-components'
-import {
-  Transaction,
-  TransactionState,
-  TransactionStatus,
-  useApproveErc20,
-  useTransaction,
-  useUsersAddress
-} from '@pooltogether/wallet-connection'
+import { Transaction, TransactionStatus, useUsersAddress } from '@pooltogether/wallet-connection'
 import { ModalApproveGate } from '@views/Deposit/ModalApproveGate'
 import { ModalLoadingGate } from '@views/Deposit/ModalLoadingGate'
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export interface ReviewTransactionViewProps extends ViewProps {
@@ -24,7 +16,6 @@ export interface ReviewTransactionViewProps extends ViewProps {
   sendTransaction: () => void
   clearTransaction: () => void
   connectWallet: () => void
-  setApproveTransactionId?: (id: string) => void
   isFetched?: boolean
   successView?: React.ReactNode
   reviewView?: React.ReactNode
@@ -54,8 +45,7 @@ export const ReviewTransactionView: React.FC<ReviewTransactionViewProps> = (prop
     amount,
     spenderAddress,
     tokenAddress,
-    buttonTexti18nKey,
-    setApproveTransactionId: _setApproveTransactionId
+    buttonTexti18nKey
   } = props
   const { chainId } = useSelectedChainId()
   const prizePool = useSelectedPrizePool()
@@ -64,22 +54,10 @@ export const ReviewTransactionView: React.FC<ReviewTransactionViewProps> = (prop
   const {
     data: allowanceUnformatted,
     isFetched: isTokenAllowanceFetched,
-    refetch: refetchTokenAllowance,
     isIdle
   } = useTokenAllowance(chainId, usersAddress, spenderAddress, tokenAddress)
-  const [approveTransactionId, setApproveTransactionId] = useState('')
-  const approveTransaction = useTransaction(approveTransactionId)
-  const _sendApproveTx = useApproveErc20(tokenAddress, spenderAddress, {
-    callbacks: { onSuccess: () => refetchTokenAllowance() }
-  })
   const { isFetched: isTokensFetched } = usePrizePoolTokens(prizePool)
   const amountUnformatted = amount?.amountUnformatted
-
-  const sendApproveTx = async () => {
-    const transactionId = await _sendApproveTx()
-    setApproveTransactionId(transactionId)
-    _setApproveTransactionId?.(transactionId)
-  }
 
   const { t } = useTranslation()
 
@@ -100,8 +78,8 @@ export const ReviewTransactionView: React.FC<ReviewTransactionViewProps> = (prop
           connectWallet={connectWallet}
           amountToDeposit={amount}
           chainId={chainId}
-          approveTx={approveTransaction}
-          sendApproveTx={sendApproveTx}
+          spenderAddress={spenderAddress}
+          tokenAddress={tokenAddress}
         />
       </>
     )

--- a/src/views/Deposit/ModalApproveGate.tsx
+++ b/src/views/Deposit/ModalApproveGate.tsx
@@ -43,17 +43,24 @@ export const ModalApproveGate = (props: ModalApproveGateProps) => {
     spenderAddress,
     tokenAddress
   )
+  const [isInfiniteApproval, setIsInfiniteApproval] = useState(true)
   const [approveTransactionId, setApproveTransactionId] = useState('')
   const approveTransaction = useTransaction(approveTransactionId)
-  const _sendApproveTx = useApproveErc20(tokenAddress, spenderAddress, {
+  const _sendInfiniteApproveTx = useApproveErc20(tokenAddress, spenderAddress, {
     callbacks: { onSuccess: () => refetchTokenAllowance() }
   })
-  const [isInfiniteApproval, setIsInfiniteApproval] = useState(true)
+  const _sendApproveTx = useApproveErc20(
+    tokenAddress,
+    spenderAddress,
+    {
+      callbacks: { onSuccess: () => refetchTokenAllowance() }
+    },
+    amountToDeposit.amountUnformatted
+  )
   const { t } = useTranslation()
 
-  // TODO: send non-infinite approval if `isInfiniteApproval` is false
   const sendApproveTx = async () => {
-    const transactionId = await _sendApproveTx()
+    const transactionId = await (isInfiniteApproval ? _sendInfiniteApproveTx() : _sendApproveTx())
     setApproveTransactionId(transactionId)
   }
 

--- a/src/views/Deposit/ModalApproveGate.tsx
+++ b/src/views/Deposit/ModalApproveGate.tsx
@@ -1,44 +1,64 @@
 import { ModalInfoList } from '@components/InfoList'
 import { EstimatedDepositGasItems } from '@components/InfoList/EstimatedGasItem'
 import { TxButton } from '@components/Input/TxButton'
-import { Amount } from '@pooltogether/hooks'
+import { Amount, useTokenAllowance } from '@pooltogether/hooks'
 import {
   ButtonLink,
   ButtonTheme,
   ThemedClipSpinner,
-  ButtonRadius
+  ButtonRadius,
+  CheckboxInputGroup
 } from '@pooltogether/react-components'
 import {
   formatBlockExplorerTxUrl,
-  Transaction,
-  TransactionState
+  TransactionState,
+  useApproveErc20,
+  useTransaction,
+  useUsersAddress
 } from '@pooltogether/wallet-connection'
 import { DepositLowAmountWarning } from '@views/DepositLowAmountWarning'
 import classNames from 'classnames'
-import React from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface ModalApproveGateProps {
   className?: string
   amountToDeposit?: Amount
   chainId: number
-  approveTx: Transaction
-  sendApproveTx: () => void
   connectWallet?: () => void
+  spenderAddress: string
+  tokenAddress: string
 }
 
 /**
- * TODO: Make max approval optional
  * @param props
  * @returns
  */
 export const ModalApproveGate = (props: ModalApproveGateProps) => {
-  const { className, chainId, approveTx, sendApproveTx, connectWallet, amountToDeposit } = props
-
+  const { className, amountToDeposit, chainId, connectWallet, spenderAddress, tokenAddress } = props
+  const usersAddress = useUsersAddress()
+  const { refetch: refetchTokenAllowance } = useTokenAllowance(
+    chainId,
+    usersAddress,
+    spenderAddress,
+    tokenAddress
+  )
+  const [approveTransactionId, setApproveTransactionId] = useState('')
+  const approveTransaction = useTransaction(approveTransactionId)
+  const _sendApproveTx = useApproveErc20(tokenAddress, spenderAddress, {
+    callbacks: { onSuccess: () => refetchTokenAllowance() }
+  })
+  const [isInfiniteApproval, setIsInfiniteApproval] = useState(true)
   const { t } = useTranslation()
 
-  if (approveTx?.state === TransactionState.pending) {
-    const blockExplorerUrl = formatBlockExplorerTxUrl(approveTx.response?.hash, chainId)
+  // TODO: send non-infinite approval if `isInfiniteApproval` is false
+  const sendApproveTx = async () => {
+    const transactionId = await _sendApproveTx()
+    setApproveTransactionId(transactionId)
+  }
+
+  if (approveTransaction?.state === TransactionState.pending) {
+    const blockExplorerUrl = formatBlockExplorerTxUrl(approveTransaction.response?.hash, chainId)
 
     return (
       <div className={classNames(className, 'flex flex-col')}>
@@ -64,6 +84,7 @@ export const ModalApproveGate = (props: ModalApproveGateProps) => {
     )
   }
 
+  // TODO: redo explanations now that users can opt out of infinite approvals
   return (
     <div className={classNames(className, 'flex flex-col')}>
       <div className='mx-4 text-inverse opacity-60'>
@@ -98,12 +119,24 @@ export const ModalApproveGate = (props: ModalApproveGateProps) => {
         radius={ButtonRadius.full}
         chainId={chainId}
         onClick={sendApproveTx}
-        state={approveTx?.state}
-        status={approveTx?.status}
+        state={approveTransaction?.state}
+        status={approveTransaction?.status}
         connectWallet={connectWallet}
       >
         {t('confirmApproval', 'Confirm approval')}
       </TxButton>
+      <div className='flex justify-end mt-2 mr-2 text-xxs'>
+        <CheckboxInputGroup
+          large
+          id='infinite-approval-toggle'
+          name='infinite-approval-toggle'
+          label={'Infinite approval'}
+          checked={isInfiniteApproval}
+          handleClick={() => {
+            setIsInfiniteApproval(!isInfiniteApproval)
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/src/views/Deposit/ModalApproveGate.tsx
+++ b/src/views/Deposit/ModalApproveGate.tsx
@@ -91,7 +91,6 @@ export const ModalApproveGate = (props: ModalApproveGateProps) => {
     )
   }
 
-  // TODO: redo explanations now that users can opt out of infinite approvals
   return (
     <div className={classNames(className, 'flex flex-col')}>
       <div className='mx-4 text-inverse opacity-60'>
@@ -101,7 +100,7 @@ export const ModalApproveGate = (props: ModalApproveGateProps) => {
             `PoolTogether's Prize Pool contracts require you to send an approval transaction before depositing.`
           )}
         </p>
-        <p className='mb-4'>{t('thisIsOncePerNetwork', 'This is necessary once per network.')}</p>
+        <p className='mb-4'>{t('thisIsOncePerNetworkIfInfinite')}</p>
         <p className='mb-10'>
           {t('forMoreInfoOnApprovals', `For more info on approvals see:`)}{' '}
           <a
@@ -137,7 +136,7 @@ export const ModalApproveGate = (props: ModalApproveGateProps) => {
           large
           id='infinite-approval-toggle'
           name='infinite-approval-toggle'
-          label={'Infinite approval'}
+          label={t('infiniteApproval')}
           checked={isInfiniteApproval}
           handleClick={() => {
             setIsInfiniteApproval(!isInfiniteApproval)


### PR DESCRIPTION
This PR moves some approval transaction logic from `src/components/ModalViews/ReviewTransactionView.tsx` to `src/views/Deposit/ModalApproveGate.tsx`, enabling swapping between infinite approvals and approvals of only the desired deposit amount.

Infinite approvals are enabled by default.

![image](https://user-images.githubusercontent.com/22108522/208732631-e6f08579-efd1-49f1-852a-0be661a9627e.png)

The description on the modal was changed slightly to the following:

![image](https://user-images.githubusercontent.com/22108522/208732923-dfe8569d-59a5-499b-8543-b65389d2dc31.png)
