### PR TITLE
Approval Bug Fixes

### DIFF
--- a/src/components/ModalViews/ReviewTransactionView.tsx
+++ b/src/components/ModalViews/ReviewTransactionView.tsx
@@ -34,6 +34,7 @@ export interface ReviewTransactionViewProps extends ViewProps {
   eip2612DelegationPermit?: ERC2612PermitMessage & RSV
   setEip2612DepositPermit?: (permit: ERC2612PermitMessage & RSV) => void
   setEip2612DelegationPermit?: (permit: ERC2612TicketPermitMessage & RSV) => void
+  skipApproval?: boolean
 }
 
 /**
@@ -61,7 +62,8 @@ export const ReviewTransactionView: React.FC<ReviewTransactionViewProps> = (prop
     eip2612DepositPermit,
     eip2612DelegationPermit,
     setEip2612DepositPermit,
-    setEip2612DelegationPermit
+    setEip2612DelegationPermit,
+    skipApproval
   } = props
   const { chainId } = useSelectedChainId()
   const prizePool = useSelectedPrizePool()
@@ -119,6 +121,7 @@ export const ReviewTransactionView: React.FC<ReviewTransactionViewProps> = (prop
     )
   } else if (
     !isIdle &&
+    !skipApproval &&
     !!amountUnformatted &&
     allowanceUnformatted?.lt(amountUnformatted) &&
     !hasAllValidApprovalSignatures()

--- a/src/components/ModalViews/WithdrawReviewView.tsx
+++ b/src/components/ModalViews/WithdrawReviewView.tsx
@@ -57,6 +57,7 @@ export const WithdrawReviewView: React.FC<
         </div>
       }
       successView={<div className='flex flex-col space-y-4'>{successView}</div>}
+      skipApproval={true}
     />
   )
 }

--- a/src/views/Account/V4DepositList/BalanceModal/index.tsx
+++ b/src/views/Account/V4DepositList/BalanceModal/index.tsx
@@ -1,19 +1,24 @@
 import { DepositReviewViewCore } from '@components/ModalViews/DepositReviewViewCore'
 import { WalletConnectionView } from '@components/ModalViews/WalletConnectionView'
 import { WithdrawReviewView } from '@components/ModalViews/WithdrawReviewView'
+import { SUPPORTED_EIP2612_PRIZE_POOL_IDS } from '@constants/config'
 import { useSelectedChainId } from '@hooks/useSelectedChainId'
+import { useSelectedPrizePool } from '@hooks/v4/PrizePool/useSelectedPrizePool'
 import { useSelectedPrizePoolTokens } from '@hooks/v4/PrizePool/useSelectedPrizePoolTokens'
 import { useSendDepositTransaction } from '@hooks/v4/PrizePool/useSendDepositTransaction'
 import { useSendWithdrawTransaction } from '@hooks/v4/PrizePool/useSendWithdrawTransaction'
 import { Amount } from '@pooltogether/hooks'
 import { BottomSheetWithViewState, ModalWithViewStateView } from '@pooltogether/react-components'
+import { ERC2612PermitMessage, ERC2612TicketPermitMessage } from '@pooltogether/v4-client-js'
 import {
   getChainNameByChainId,
   TransactionState,
   useTransaction
 } from '@pooltogether/wallet-connection'
+import { ApprovalType } from '@views/Deposit/DepositTrigger/DepositModal'
+import { RSV } from 'eth-permit/dist/rpc'
 import { useTranslation } from 'next-i18next'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { PrizePoolInfoView } from '../../../../components/ModalViews/PrizePoolInfoView'
 import { DelegateView } from '../DelegateView'
 import { DepositView } from './DepositView'
@@ -46,9 +51,40 @@ export const BalanceModal: React.FC<{
   const depositTransaction = useTransaction(depositTransactionId)
   const withdrawTransaction = useTransaction(withdrawTransactionId)
   const [viewId, setViewId] = useState<string | number>(ViewIds.main)
+  const prizePool = useSelectedPrizePool()
   const { t } = useTranslation()
 
-  const sendDepositTransaction = useSendDepositTransaction(depositAmount)
+  const defaultApprovalType: ApprovalType = SUPPORTED_EIP2612_PRIZE_POOL_IDS.includes(
+    prizePool.id()
+  )
+    ? 'eip2612'
+    : 'infinite'
+  const [approvalType, setApprovalType] = useState<ApprovalType>(defaultApprovalType)
+  const [eip2612DepositPermit, setEip2612DepositPermit] = useState<ERC2612PermitMessage & RSV>()
+  const [eip2612DelegationPermit, setEip2612DelegationPermit] = useState<
+    ERC2612TicketPermitMessage & RSV
+  >()
+  useEffect(() => {
+    setApprovalType(defaultApprovalType)
+  }, [defaultApprovalType])
+
+  /**
+   * Submit the transaction to deposit and store the transaction id in state
+   */
+  const _sendDepositTransaction = useSendDepositTransaction(
+    depositAmount,
+    approvalType === 'eip2612'
+      ? {
+          depositPermit: eip2612DepositPermit,
+          delegationPermit: eip2612DelegationPermit
+        }
+      : undefined
+  )
+  const sendDepositTransaction = useCallback(
+    () => setDepositTransactionId(_sendDepositTransaction()),
+    [_sendDepositTransaction]
+  )
+
   const sendWithdrawTransaction = useSendWithdrawTransaction(withdrawAmount)
 
   const views: ModalWithViewStateView[] = [
@@ -139,9 +175,16 @@ export const BalanceModal: React.FC<{
       formAmount={formAmount}
       setFormAmount={setFormAmount}
       clearDepositTransaction={() => setDepositTransactionId('')}
-      // DepositReviewView
+      // DepositReviewViewCore
       depositAmount={depositAmount}
-      sendDepositTransaction={() => setDepositTransactionId(sendDepositTransaction())}
+      sendDepositTransaction={sendDepositTransaction}
+      // reviewView
+      approvalType={approvalType}
+      setApprovalType={setApprovalType}
+      eip2612DepositPermit={eip2612DepositPermit}
+      eip2612DelegationPermit={eip2612DelegationPermit}
+      setEip2612DepositPermit={setEip2612DepositPermit}
+      setEip2612DelegationPermit={setEip2612DelegationPermit}
       // WithdrawView
       withdrawTransaction={withdrawTransaction}
       setWithdrawAmount={setWithdrawAmount}


### PR DESCRIPTION
In order to skip allowance checks when following the withdrawal flow, a simple `skipApprovals` prop is being passed to the `ReviewTransactionView`.

While testing this change, I discovered that since the `ReviewTransactionView` component is called from multiple different locations in the app, some of the logic from #117 needed to also be copied over to those other sources.

Ideally these components would be refactored into one common deposit flow, but with the copied logic the flow is now fully working and will allow us to push through with the new signature approval changes.

The files affected are the following:
- `src/components/Modal/DepositModal/index.tsx`
- `src/views/Account/V4DepositList/BalanceModal/index.tsx`