### PR TITLE
Fixed OP Promotion Number Formatting

### DIFF
--- a/src/views/Account/Rewards/RewardsCard.tsx
+++ b/src/views/Account/Rewards/RewardsCard.tsx
@@ -29,9 +29,9 @@ import {
   numberWithCommas,
   getNetworkNameAliasByChainId,
   getNetworkNiceNameByChainId,
-  sToD
+  sToD,
+  getAmountFromUnformatted
 } from '@pooltogether/utilities'
-import { getAmount } from '@pooltogether/utilities'
 import {
   useSendTransaction,
   useUsersAddress,
@@ -434,7 +434,7 @@ const ClaimModalForm = (props: {
 
   const { value, unit, seconds } = getNextRewardIn(promotion)
 
-  const amount = getAmount(usersClaimedPromotionHistory?.rewards, decimals)
+  const amount = getAmountFromUnformatted(usersClaimedPromotionHistory?.rewards, decimals)
 
   const vapr = usePromotionVAPR(promotion)
 


### PR DESCRIPTION
The value returned from the subgraph includes decimals, and had even more decimals being added to it (at least the prettified version) through the `getAmount` method. This resulted in inconsistent number rounding/formatting.

This was updated to use the `getAmountFromUnformatted` instead.

The wallet of the user who first reported this error was tested, and it now formats their claimed value correctly (`0.51` instead of `506.00`).