### PR TITLE
Removed V3 App Link

### DIFF
--- a/src/views/Account/V3DepositList/index.tsx
+++ b/src/views/Account/V3DepositList/index.tsx
@@ -44,23 +44,9 @@ export const V3DepositList = () => {
           title={`V3 ${t('deposits')}`}
           secondary={`$${data.totalValueUsd.amountPretty}`}
         />
-        <V3AppLink />
       </div>
       <DepositsList data={data} refetch={refetchBalances} />
     </div>
-  )
-}
-
-const V3AppLink = () => {
-  const { t } = useTranslation()
-  return (
-    <a
-      className='opacity-50 hover:opacity-100 flex items-center transition-opacity'
-      href='https://v3.pooltogether.com'
-    >
-      {t('v3App', 'V3 App')}
-      <FeatherIcon icon='external-link' className='w-4 h-4 ml-1' />
-    </a>
   )
 }
 


### PR DESCRIPTION
When users have a V3 deposit shown on their account page, we were still linking them to the V3 app, where they would inevitably just be linked back to where they just came from.