### PR TITLE
Adds Support for Apex Wallet as a Rainbow Wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/react": "^18.0.20",
     "@types/react-dom": "^18.0.6",
     "@wagmi/chains": "^0.1.13",
+    "apex-integration": "^1.0.9",
     "autoprefixer": "^10.3.1",
     "beautiful-react-hooks": "^3.6.2",
     "classnames": "^2.3.1",

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -29,6 +29,7 @@ import { FathomEvent, logEvent } from '@utils/services/fathom'
 import { initSentry } from '@utils/services/initSentry'
 import { jsonRpcProvider } from '@wagmi/core/providers/jsonRpc'
 import { publicProvider } from '@wagmi/core/providers/public'
+import { apexRainbowWallet } from 'apex-integration'
 import * as Fathom from 'fathom-client'
 import { Provider as JotaiProvider } from 'jotai'
 import { AppProps } from 'next/app'
@@ -68,6 +69,7 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Recommended',
     wallets: [
+      apexRainbowWallet({ chains: supportedChains }),
       injectedWallet({ chains: supportedChains }),
       walletConnectWallet({ chains: supportedChains }),
       coinbaseWallet({ chains: supportedChains, appName: 'PoolTogether' }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4248,6 +4248,11 @@ anymatch@^3.0.3, anymatch@~3.1.1, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apex-integration@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/apex-integration/-/apex-integration-1.0.9.tgz#bee57c13784879012390df298f53e1af45386796"
+  integrity sha512-5DUBRso9ywqmo/kxJNXrQ8WVIoPTsitLdD0A9XOkKRMsIPGTygUQ/TR6RGOlUexW0B7YcMNV2TyNHkUECiX3KQ==
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"


### PR DESCRIPTION
# This PR
- Adds [Apex Wallet](https://apexwallet.xyz/) as a [custom Rainbow wallet](https://www.rainbowkit.com/docs/custom-wallet-list) so users can connect to PoolTogether using their Apex wallet.

# Context
<img width="984" alt="Screenshot 2023-02-13 at 7 00 50 PM" src="https://user-images.githubusercontent.com/115434845/218607790-759a09a6-a19c-4e1d-a69e-c94765f1641c.png">
