### PR TITLE
Updated Fathom CDN Script

### DIFF
--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -50,7 +50,7 @@ export const AppContainer: React.FC<AppProps> = (props) => {
     const fathomSiteId = process.env.NEXT_PUBLIC_FATHOM_SITE_ID
     if (fathomSiteId) {
       Fathom.load(process.env.NEXT_PUBLIC_FATHOM_SITE_ID, {
-        url: 'https://goose.pooltogether.com/script.js',
+        url: 'https://cdn.usefathom.com/script.js',
         includedDomains: ['app.pooltogether.com', 'v4.pooltogether.com']
       })
       const onRouteChangeComplete = (url) => {


### PR DESCRIPTION
This PR updates the source for the script being used by Fathom to generate site analytics.

This [article](https://usefathom.com/docs/script/custom-domains) from a while ago details the end of support for custom domains (like the one we are using), and while it still technically works, its SSL certificate is no longer valid and it means that the app shows as "not secure" on some browser configurations.